### PR TITLE
fix issue 24

### DIFF
--- a/src/main/java/com/upokecenter/cbor/CBORUtilities.java
+++ b/src/main/java/com/upokecenter/cbor/CBORUtilities.java
@@ -1517,6 +1517,8 @@ ValueNormalDays :
         int newmant = ((int)(mant >> 42));
         return ((mant & ((1L << 42) - 1)) == 0) ? (sign | 0x7c00 | newmant) :
           -1;
+      } else if (exp == 0 && mant == 0) { // positive or negative zero always fits in half precision
+        return sign;
       } else if (sexp >= 31) { // overflow
         return -1;
       } else if (sexp < -10) { // underflow
@@ -1524,7 +1526,7 @@ ValueNormalDays :
       } else if (sexp > 0) { // normal
         return ((mant & ((1L << 42) - 1)) == 0) ? (sign | (sexp << 10) |
             RoundedShift(mant, 42)) : -1;
-      } else { // subnormal and zero
+      } else { // subnormal but nonzero
         int rs = RoundedShift(mant | (1L << 52), 42 - (sexp - 1));
         // System.out.println("mant=" + mant + " rs=" + (rs));
         return sexp == -10 && rs == 0 ? -1 :

--- a/src/test/java/com/upokecenter/test/CBORNumberTest.java
+++ b/src/test/java/com/upokecenter/test/CBORNumberTest.java
@@ -261,6 +261,43 @@ import com.upokecenter.numbers.*;
     }
 
     @Test
+    public void TestEncodingZeros() {
+        TestCommon.CompareTestEqual(ToCN(0.0), ToCN(-0.0).Abs());
+        TestCommon.CompareTestEqual(ToCN(0.0f), ToCN(-0.0f).Abs());
+
+        if (!CBORObject.FromObject(0.0).AsNumber().CanFitInSingle()) {
+            Assert.fail();
+        }
+        if (!CBORObject.FromObject(-0.0).AsNumber().CanFitInSingle()) {
+            Assert.fail();
+        }
+        if (!CBORObject.FromObject(0.0f).AsNumber().CanFitInSingle()) {
+            Assert.fail();
+        }
+        if (!CBORObject.FromObject(-0.0f).AsNumber().CanFitInSingle()) {
+            Assert.fail();
+        }
+
+        ToObjectTest.TestToFromObjectRoundTrip(0.0);
+        ToObjectTest.TestToFromObjectRoundTrip(0.0f);
+        ToObjectTest.TestToFromObjectRoundTrip(-0.0);
+        ToObjectTest.TestToFromObjectRoundTrip(-0.0f);
+
+        TestCommon.CompareTestEqual(ToCN(0.0), CBORObject.FromObject(-0.0).AsNumber().Negate());
+        TestCommon.CompareTestEqual(ToCN(-0.0), CBORObject.FromObject(0.0).AsNumber().Negate());
+        TestCommon.CompareTestEqual(ToCN(0.0f), CBORObject.FromObject(-0.0f).AsNumber().Negate());
+        TestCommon.CompareTestEqual(ToCN(-0.0f), CBORObject.FromObject(0.0f).AsNumber().Negate());
+
+        assert (CBORObject.FromObject(1.0f).EncodeToBytes().length == 3);
+        assert (CBORObject.FromObject(1.0).EncodeToBytes().length == 3);
+        assert (CBORObject.FromObject(0.0f).EncodeToBytes().length == 3);
+        assert (CBORObject.FromObject(-0.0f).EncodeToBytes().length == 3);
+        assert (CBORObject.FromObject(0.0).EncodeToBytes().length == 3);
+        assert (CBORObject.FromObject(-0.0).EncodeToBytes().length == 3);
+    }
+
+
+    @Test
     public void TestNegate() {
       // not implemented yet
     }


### PR DESCRIPTION
This PR ensures the minimum-precision encoding of `Double` values `0.0` and `-0.0`. The existing code fails to detect that these values fit in half-precision (16-bit) floats.

The 32-bit floats seem to be working fine.